### PR TITLE
WIP: [typescript] Add additional numeric enum variant when generating…

### DIFF
--- a/src/idl_gen_js_ts.cpp
+++ b/src/idl_gen_js_ts.cpp
@@ -380,6 +380,20 @@ class JsTsGenerator : public BaseGenerator {
       }
     }
 
+    if (lang_.language == IDLOptions::kTs && parser_.opts.ts_string_enums) {
+      // Also add a numeric variant when using string enums, this way a two way
+      // conversion is possible (numeric enum members have a reverse mapping)
+      code += "}\n";
+      code += "export enum " + enum_def.name + "Numeric{\n";
+      for (auto it = enum_def.Vals().begin(); it != enum_def.Vals().end();
+           ++it) {
+        auto &ev = **it;
+        code += "  " + ev.name + "= ";
+        code += enum_def.ToString(ev);
+        code += (it + 1) != enum_def.Vals().end() ? ",\n" : "\n";
+      }
+    }
+
     if (lang_.language == IDLOptions::kTs && !ns.empty()) { code += "}"; }
     code += "};\n\n";
   }


### PR DESCRIPTION
Generates something alike;
```export namespace ac.fbs.protocol{
export enum DataType{
  boolean= 'boolean',
  u8= 'u8',
  s8= 's8',
  u16= 'u16',
  s16= 's16',
  u32= 'u32',
  s32= 's32',
  u64= 'u64',
  s64= 's64',
  f32= 'f32',
  f64= 'f64'
}
export enum DataTypeNumeric{
  boolean= 0,
  u8= 1,
  s8= 2,
  u16= 3,
  s16= 4,
  u32= 5,
  s32= 6,
  u64= 7,
  s64= 8,
  f32= 9,
  f64= 10
}};